### PR TITLE
Adicionar Testes Unitários para o Controlador TokenController

### DIFF
--- a/StockApp.API/Controllers/TokenController.cs
+++ b/StockApp.API/Controllers/TokenController.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using StockApp.Application.Interfaces;
 using StockApp.Application.DTOs;
+using StockApp.Application.Interfaces;
 using System.Threading.Tasks;
 
 namespace StockApp.API.Controllers
@@ -19,6 +19,11 @@ namespace StockApp.API.Controllers
         [HttpPost("login")]
         public async Task<IActionResult> Login([FromBody] UserLoginDTO userLoginDTO)
         {
+            if (string.IsNullOrEmpty(userLoginDTO.Username) || string.IsNullOrEmpty(userLoginDTO.Password))
+            {
+                return BadRequest();
+            }
+
             var token = await _authService.AuthenticateAsync(userLoginDTO.Username, userLoginDTO.Password);
 
             if (token == null)

--- a/StockApp.Domain.Test/StockApp.Domain.Test.csproj
+++ b/StockApp.Domain.Test/StockApp.Domain.Test.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\StockApp.API\StockApp.API.csproj" />
     <ProjectReference Include="..\StockApp.Application\StockApp.Application.csproj" />
     <ProjectReference Include="..\StockApp.Domain\StockApp.Domain.csproj" />
   </ItemGroup>

--- a/StockApp.Domain.Test/TokenControllerTests.cs
+++ b/StockApp.Domain.Test/TokenControllerTests.cs
@@ -1,0 +1,62 @@
+﻿using Moq;
+using Xunit;
+using Microsoft.AspNetCore.Mvc;
+using StockApp.API.Controllers;
+using StockApp.Application.Interfaces;
+using StockApp.Application.DTOs;
+using System.Threading.Tasks;
+
+public class TokenControllerTests
+{
+    private readonly Mock<IAuthService> _authServiceMock;
+    private readonly TokenController _tokenController;
+
+    public TokenControllerTests()
+    {
+        _authServiceMock = new Mock<IAuthService>();
+        _tokenController = new TokenController(_authServiceMock.Object);
+    }
+
+    [Fact]
+    public async Task Login_ValidCredentials_ReturnsToken()
+    {
+        // Arrange
+        _authServiceMock.Setup(service => service.AuthenticateAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new TokenResponseDTO
+        {
+            Token = "token",
+            Expiration = DateTime.UtcNow.AddMinutes(60)
+        });
+
+        var userLoginDto = new UserLoginDTO
+        {
+            Username = "testuser",
+            Password = "password"
+        };
+
+        // Act
+        var result = await _tokenController.Login(userLoginDto) as OkObjectResult;
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(200, result.StatusCode);
+        Assert.IsType<TokenResponseDTO>(result.Value);
+    }
+
+    [Fact]
+    public async Task Login_EmptyCredentials_ReturnsBadRequest()
+    {
+        // Arrange
+        var userLoginDto = new UserLoginDTO
+        {
+            Username = "",
+            Password = ""
+        };
+
+        // Act
+        var result = await _tokenController.Login(userLoginDto) as BadRequestResult;
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(400, result.StatusCode);
+    }
+}


### PR DESCRIPTION
- Updated `TokenController.cs` to include async programming support with `System.Threading.Tasks;` and added validation for `Username` and `Password` in the `Login` method to return `BadRequest` for null or empty inputs. Also, fixed the closing brace for proper syntax.
- Added a project reference to `StockApp.API.csproj` in `StockApp.Domain.Test.csproj` to enable testing of API components.
- Created a new test class `TokenControllerTests` in `TokenControllerTests.cs` with tests for valid and empty credentials, ensuring correct responses are returned. This includes setup with Moq and Xunit for isolated testing of the `TokenController`.