### PR TITLE
Configurar Taxa de Limitação (Rate Limiting)

### DIFF
--- a/StockApp.API/StockApp.API.csproj
+++ b/StockApp.API/StockApp.API.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
     <PackageReference Include="Comtele.Sdk" Version="1.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />

--- a/StockApp.API/appsettings.json
+++ b/StockApp.API/appsettings.json
@@ -17,5 +17,19 @@
   },
   "Comtele": {
     "ApiKey": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+  },
+  "IpRateLimiting": {
+    "EnableEndpointRateLimiting": true,
+    "StackBlockedRequests": false,
+    "RealIpHeader": "X-Real-IP",
+    "ClientIdHeader": "X-ClientId",
+    "HttpStatusCode": 429,
+    "GeneralRules": [
+      {
+        "Endpoint": "*",
+        "Period": "1m",
+        "Limit": 100
+      }
+    ]
   }
 }


### PR DESCRIPTION
- Removed unused `using` directives in Startup.cs for cleaner imports.
- Added `AspNetCoreRateLimit` package and configuration for rate limiting.
- Reorganized `using` directives and some service registrations in Startup.cs.
- Removed Serilog configuration from Startup.cs and `app.UseSerilogRequestLogging()` middleware, indicating a logging configuration change.
- Added `app.UseIpRateLimiting()` middleware to enforce rate limiting.
- Updated `StockApp.API.csproj` with `AspNetCoreRateLimit` version `5.0.0`.
- Enhanced `appsettings.json` with `IpRateLimiting` configuration for detailed rate limiting setup.