### PR TITLE
Implementar Suporte a Internacionalização (i18n)

### DIFF
--- a/StockApp.API/Startup.cs
+++ b/StockApp.API/Startup.cs
@@ -14,6 +14,8 @@ using StockApp.Infra.Data.Repositories;
 using System.Security.Claims;
 using System.Text;
 using StockApp.Application.Mappings;
+using Microsoft.AspNetCore.Localization;
+using System.Globalization;
 
 public class Startup
 {
@@ -104,9 +106,9 @@ public class Startup
             c.AddSecurityDefinition("Bearer", securityScheme);
 
             var securityRequirement = new OpenApiSecurityRequirement
-            {
-                { securityScheme, new[] { "Bearer" } }
-            };
+        {
+            { securityScheme, new[] { "Bearer" } }
+        };
 
             c.AddSecurityRequirement(securityRequirement);
         });
@@ -121,6 +123,22 @@ public class Startup
                            .AllowAnyMethod()
                            .AllowAnyHeader();
                 });
+        });
+
+        services.AddLocalization(options => options.ResourcesPath = "Resources");
+
+        services.Configure<RequestLocalizationOptions>(options =>
+        {
+            var supportedCultures = new[]
+            {
+            new CultureInfo("en-US"),
+            new CultureInfo("pt-BR")
+            // Adicione mais culturas conforme necessário
+        };
+
+            options.DefaultRequestCulture = new RequestCulture("en-US");
+            options.SupportedCultures = supportedCultures;
+            options.SupportedUICultures = supportedCultures;
         });
     }
 

--- a/StockApp.API/StockApp.API.csproj
+++ b/StockApp.API/StockApp.API.csproj
@@ -13,9 +13,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Localization" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.31" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />


### PR DESCRIPTION
- Implemented localization support by adding `Microsoft.AspNetCore.Localization` and `Microsoft.Extensions.Localization` packages to `StockApp.API.csproj`.
- Configured localization services in `Startup.cs`, including setting the default request culture to `en-US` and specifying supported cultures (`en-US`, `pt-BR`).
- Updated OpenApi security requirement syntax in `Startup.cs` for better readability and alignment with current standards.