### PR TITLE
Criar Procedure em MySQL para Relatório de Estoque

### DIFF
--- a/StockApp.Infra.Data/Migrations/20240621235100_procedure.cs
+++ b/StockApp.Infra.Data/Migrations/20240621235100_procedure.cs
@@ -19,6 +19,18 @@ namespace StockApp.Infra.Data.Migrations
                       GROUP BY p.Name;
                   END;");
 
+            migrationBuilder.Sql(@"
+                DELIMITER //
+
+                CREATE PROCEDURE GetStockReport()
+                BEGIN
+                    SELECT Name, Stock
+                    FROM Products;
+                END //
+
+                DELIMITER ;
+            ");
+
             migrationBuilder.DropForeignKey(
                 name: "FK_Products_Categories_CategoryId",
                 table: "Products");


### PR DESCRIPTION
- Modified namespace `StockApp.Infra.Data.Migrations` to include updates related to database procedures and adjustments to foreign key constraints.
- Added a new SQL stored procedure `GetStockReport` for selecting `Name` and `Stock` from the `Products` table, utilizing `DELIMITER //` for procedure block definition.
- Implemented `DELIMITER` keyword usage to facilitate semicolon within the stored procedure, ensuring proper SQL command execution.
- Removed foreign key constraint `FK_Products_Categories_CategoryId` from the `Products` table, indicating a schema change or redefinition of the relationship between products and categories.